### PR TITLE
Captures stderr so the progress bar is visible in the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In you are performing a stratified analysis, you can have each strata processed 
 
 ## Run EWAS
 
-Once you have modified the `.config` file to match your projects specifications and computational resources you are ready to run the EWAS. 
+Once you have modified the `config.yml` file to match your projects specifications and computational resources you are ready to run the EWAS. 
 
 For a standard (non-stratified) EWAS:
 ```shell

--- a/rules/stratified_ewas.smk
+++ b/rules/stratified_ewas.smk
@@ -60,7 +60,7 @@ for group in GROUPS:
             --out-dir {{params.o_dir}} \
             --out-type {{params.o_type}} \
             --out-prefix {{params.o_prefix}} \
-            > {{log}}
+            > {{log}} 2>&1
             """
     rule:
         name:


### PR DESCRIPTION
I believe this PR addresses #7, specifically that the progress bars appeared to be missing from the log output.

The PR changes how  the `run_ewas_*` step writes to the logfile; before, it would only write stdout, but since the progress bars were being written to stderr they were missing from the logs. The change now redirects stderr to stdout, then writes the combined stdout/stderr output to the logfile.

If for some reason you don't want stdout and stderr to be interleaved in the resulting logfile, you could instead write stderr to its own file. The changed line in `stratified_ewas.smk` might then look like `> {{log}} 2> {{log}}.err`, which would produce an a file `M_ewas.log.err` containing just the stderr output (in this case, the progress bar) in addition to `M_ewas.log` which would just contain stdout.

If you want to monitor the progress of the jobs in realtime, an easy way to do that is to run `tail -F log/M_ewas.log log/F_ewas.log`. The `-F`, like `-f`, is for "follow", but it differs from `-f` in that it'll continue to try to track the files' output even if they're deleted or truncated. Since `tail` outputs on a line-by-line basis, the two processes won't interfere with each others' output, unlike when they're both writing to the console.

The resulting output from `tail` over multiple files will look like this:
```
Asynchronous parallel processing using multicore with 2 worker(s). 
Starting EWAS:  M 

==> log/F_ewas.log <==
Asynchronous parallel processing using multicore with 2 worker(s). 
Starting EWAS:  F 

==> log/M_ewas.log <==
■■                                 2% |  ETA:  8s

==> log/F_ewas.log <==
■■                                 2% |  ETA:  8s

==> log/M_ewas.log <==
■■                                 4% |  ETA:  5s

==> log/F_ewas.log <==
■■                                 4% |  ETA:  5s

==> log/M_ewas.log <==
■■■                                6% |  ETA: 11s

==> log/F_ewas.log <==
■■■                                6% |  ETA: 11s
■■■                                8% |  ETA:  8s

==> log/M_ewas.log <==
■■■                                8% |  ETA:  8s
■■■■                              10% |  ETA: 10s

==> log/F_ewas.log <==
■■■■                              10% |  ETA: 10s
■■■■■                             12% |  ETA:  8s

... omitted ...

==> log/F_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■      90% |  ETA:  1s
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■     92% |  ETA:  1s

==> log/M_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■     92% |  ETA:  1s
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■     94% |  ETA:  1s

==> log/F_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■     94% |  ETA:  1s
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■    96% |  ETA:  0s

==> log/M_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■    96% |  ETA:  0s
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■    98% |  ETA:  0s

==> log/F_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■    98% |  ETA:  0s

==> log/M_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■  100% |  ETA:  0s

==> log/F_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■  100% |  ETA:  0s

==> log/M_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■  100% |  ETA:  0s

==> log/F_ewas.log <==
■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■  100% |  ETA:  0s

==> log/M_ewas.log <==
                                                                               
==> log/F_ewas.log <==
                                                                               
==> log/M_ewas.log <==
10.865 sec elapsed

==> log/F_ewas.log <==
10.861 sec elapsed
```

I also corrected what I thought was a typo in the `README.md` where it references `.config`, but from the rest of the text it seems it should be `config.yml`.
